### PR TITLE
Update base64.R

### DIFF
--- a/R/base64.R
+++ b/R/base64.R
@@ -25,10 +25,10 @@ base64encode <- function(what, linewidth, newline) {
   .Call(B64_encode, as.raw(what), linewidth, newline)
 }
 
-base64decode <- function(what, output=NULL, file) {
-  if (!missing(file) && !missing(what)) stop("'what' and 'file' are mutually exclusive")
-  if (!missing(file)) {
-    what <- file(file, "r")
+base64decode <- function(what, output=NULL, filename) {
+  if (!missing(filename) && !missing(what)) stop("'what' and 'filename' are mutually exclusive")
+  if (!missing(filename)) {
+    what <- file(filename, "r")
     on.exit(close(what))
   }
   if (is.character(output)) {


### PR DESCRIPTION
In the current version, there's a conflict between `file` as a parameter and `file()` as a function. To reproduce an error, execute:
base64decode(what='somestring', output = 'filename.ext')
it will cause an error:
Error in base64decode(what = encoded, output = "obj.rds") :
argument "file" is missing, with no default
